### PR TITLE
fix: make cookie function async

### DIFF
--- a/src/actions/cart-actions.ts
+++ b/src/actions/cart-actions.ts
@@ -5,7 +5,7 @@ import * as Commerce from "commerce-kit";
 import { revalidateTag } from "next/cache";
 
 export async function getCartFromCookiesAction() {
-	const cartJson = getCartCookieJson();
+	const cartJson = await getCartCookieJson();
 	if (!cartJson) {
 		return null;
 	}
@@ -34,7 +34,7 @@ export async function findOrCreateCartIdFromCookiesAction() {
 }
 
 export async function clearCartCookieAction() {
-	const cookie = getCartCookieJson();
+	const cookie = await getCartCookieJson();
 	if (!cookie) {
 		return;
 	}

--- a/src/app/(store)/order/success/page.tsx
+++ b/src/app/(store)/order/success/page.tsx
@@ -37,7 +37,7 @@ export default async function OrderDetailsPage(props: {
 	if (!order) {
 		return <div>Order not found</div>;
 	}
-	const cookie = getCartCookieJson();
+	const cookie = await getCartCookieJson();
 	const t = await getTranslations("/order.page");
 	const locale = await getLocale();
 

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -14,13 +14,17 @@ export function setCartCookieJson(cartCookieJson: CartCookieJson): void {
 }
 
 export function clearCartCookie(): void {
-	(cookies() as unknown as UnsafeUnwrappedCookies).set(CART_COOKIE, "", { maxAge: 0 });
+	(cookies() as unknown as UnsafeUnwrappedCookies).set(CART_COOKIE, "", {
+		maxAge: 0,
+	});
 }
 
-export function getCartCookieJson(): null | CartCookieJson {
+export async function getCartCookieJson(): Promise<null | CartCookieJson> {
+	const cookiesValue = await cookies();
 	const cartCookieJson = safeJsonParse(
-		(cookies() as unknown as UnsafeUnwrappedCookies).get(CART_COOKIE)?.value,
+		(cookiesValue as unknown as UnsafeUnwrappedCookies).get(CART_COOKIE)?.value,
 	);
+
 	if (
 		!cartCookieJson ||
 		typeof cartCookieJson !== "object" ||


### PR DESCRIPTION
I encountered with cookie error(https://github.com/yournextstore/yournextstore/issues/49) when i deploy the project in my local. 
The error in the console is: 

> In route / a cookie property was accessed directly with cookies().get('yns_cart'). cookies() should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis

I fixed this problem my making the cookies async.