### PR TITLE
refactor: remove unnecessary workaround for canonical url in metadata

### DIFF
--- a/src/app/(store)/product/[slug]/page.tsx
+++ b/src/app/(store)/product/[slug]/page.tsx
@@ -46,8 +46,7 @@ export const generateMetadata = async (props: {
 	return {
 		title: t("title", { productName }),
 		description: product.description,
-		// https://github.com/vercel/next.js/pull/65366
-		alternates: { canonical: canonical.toString() },
+		alternates: { canonical: canonical },
 	} satisfies Metadata;
 };
 


### PR DESCRIPTION
Since https://github.com/vercel/next.js/pull/65366 issue has been resolved we can simply pass a URL object as a value to canonical link in metadata object.