### PR TITLE
feat: implement banner visibility persistence using local storage

### DIFF
--- a/src/ui/banner.tsx
+++ b/src/ui/banner.tsx
@@ -5,9 +5,14 @@ import { useState } from "react";
 import { YnsLink } from "./yns-link";
 
 export const Banner = () => {
-	const [isOpen, setIsOpen] = useState(true);
+	const [isOpen, setIsOpen] = useState(() => localStorage.getItem("banner") !== "true");
 
 	if (!isOpen) return null;
+
+	const handleClose = () => {
+		setIsOpen(false);
+		localStorage.setItem("banner", "true");
+	};
 
 	return (
 		<div className="bg-gradient-to-r from-indigo-100 via-indigo-200 to-indigo-300 px-4 py-3 text-indigo-900">
@@ -26,7 +31,7 @@ export const Banner = () => {
 					</div>
 				</div>
 				<button
-					onClick={() => setIsOpen(false)}
+					onClick={handleClose}
 					className="flex-none rounded-full justify-self-end bg-indigo-500 p-1 text-white shadow-sm hover:bg-indigo-600"
 					aria-label="Close banner"
 					type="button"


### PR DESCRIPTION
#64 This PR implements banner visibility persistence using `localStorage`. Previously, the banner's visibility state was not retained across page reloads, and the banner would always be visible when the page reloaded. With these changes:
- The banner state is now stored in `localStorage`.
- If the banner has been dismissed, it will remain hidden even after the page reloads.

---

## Changes Made

### 1. State Initialization
Modified the `isOpen` state initialization to check `localStorage` for the key `"banner"`. If the key is set to `"true"`, the banner remains hidden.

```javascript
const [isOpen, setIsOpen] = useState(() => localStorage.getItem("banner") !== "true");
```

### 2. State Persistence
Added a `handleClose` function to update the `isOpen` state and persist the dismissal status in `localStorage`.

```javascript
const handleClose = () => {
    setIsOpen(false);
    localStorage.setItem("banner", "true");
};
```