### PR TITLE
Template hardening: TypeScript 6, server-reconciled cart, TipTap renderer

### DIFF
--- a/app/cart/actions.ts
+++ b/app/cart/actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { commerce } from "@/lib/commerce";
 import { CURRENCY } from "@/lib/constants";
 import { getCartCookieJson, setCartCookie } from "@/lib/cookies";
@@ -22,11 +21,21 @@ export async function getCart() {
 export async function addToCart(variantId: string, quantity = 1) {
 	const cartCookie = await getCartCookieJson();
 
-	const cart = await commerce.cartUpsert({
-		cartId: cartCookie?.id,
-		variantId,
-		quantity,
-	});
+	// The yns_cart cookie can point at a cartId that no longer exists server-side
+	// (expired, store re-seeded, old session). cartUpsert then throws "Cart not found";
+	// retry once with a FRESH cart so the add always lands. No revalidatePath — the
+	// client syncs from this action's returned cart (the layout cartGet hits a
+	// read-replica and can return the pre-write cart, dropping the just-added line).
+	let cart = null;
+	try {
+		cart = await commerce.cartUpsert({ cartId: cartCookie?.id, variantId, quantity });
+	} catch {
+		try {
+			cart = await commerce.cartUpsert({ variantId, quantity });
+		} catch {
+			return { success: false, cart: null };
+		}
+	}
 
 	if (!cart) {
 		return { success: false, cart: null };
@@ -35,7 +44,6 @@ export async function addToCart(variantId: string, quantity = 1) {
 	if (cart.id !== cartCookie?.id) {
 		await setCartCookie({ id: cart.id });
 	}
-	revalidatePath("/", "layout");
 
 	return { success: true, cart };
 }
@@ -61,7 +69,6 @@ export async function addBundleToCart(
 		if (cart.id !== cartCookie?.id) {
 			await setCartCookie({ id: cart.id });
 		}
-		revalidatePath("/", "layout");
 
 		return { success: true as const, cart };
 	} catch (error) {

--- a/app/cart/cart-context.tsx
+++ b/app/cart/cart-context.tsx
@@ -1,17 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useOptimistic,
-	useState,
-	useTransition,
-} from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, useTransition } from "react";
+import { getCart } from "@/app/cart/actions";
 
 export type CartLineItem = {
 	quantity: number;
@@ -75,6 +66,75 @@ type CartAction =
 	| { type: "REMOVE"; variantId: string }
 	| { type: "ADD_ITEM"; item: CartLineItem };
 
+// Pure reducer for INSTANT local feedback only. After every mutation the caller
+// REPLACES this with the server-returned cart (syncCart) — plain state, no rebase,
+// so a local mutation can never be re-applied on top of the authoritative cart.
+function cartReducer(state: Cart | null, action: CartAction): Cart | null {
+	if (!state) {
+		if (action.type === "ADD_ITEM") {
+			return { id: "local", lineItems: [action.item] };
+		}
+		return state;
+	}
+
+	switch (action.type) {
+		case "INCREASE":
+			return {
+				...state,
+				lineItems: state.lineItems.map((item) =>
+					item.productVariant.id === action.variantId ? { ...item, quantity: item.quantity + 1 } : item,
+				),
+			};
+
+		case "DECREASE":
+			return {
+				...state,
+				lineItems: state.lineItems
+					.map((item) => {
+						if (item.productVariant.id === action.variantId) {
+							if (item.quantity - 1 <= 0) {
+								return null;
+							}
+							return { ...item, quantity: item.quantity - 1 };
+						}
+						return item;
+					})
+					.filter((item): item is CartLineItem => item !== null),
+			};
+
+		case "REMOVE":
+			return {
+				...state,
+				lineItems: state.lineItems.filter((item) => item.productVariant.id !== action.variantId),
+			};
+
+		case "ADD_ITEM": {
+			const existingItem = state.lineItems.find(
+				(item) => item.productVariant.id === action.item.productVariant.id,
+			);
+
+			if (existingItem) {
+				return {
+					...state,
+					lineItems: state.lineItems.map((item) =>
+						item.productVariant.id === action.item.productVariant.id
+							? { ...item, quantity: item.quantity + action.item.quantity }
+							: item,
+					),
+				};
+			}
+
+			return {
+				...state,
+				lineItems: [...state.lineItems, action.item],
+			};
+		}
+
+		default:
+			return state;
+	}
+}
+
 type CartContextValue = {
 	cart: Cart | null;
 	items: CartLineItem[];
@@ -85,7 +145,12 @@ type CartContextValue = {
 	cartId: string | null;
 	openCart: () => void;
 	closeCart: () => void;
+	/** Instant local mutation for optimistic feedback. */
 	dispatch: (action: CartAction) => void;
+	/** Replace local state with the server's authoritative cart (no-op on null). */
+	syncCart: (next: Cart | null) => void;
+	/** Refetch the authoritative cart from the server — call only when a write FAILED. */
+	reconcile: () => Promise<void>;
 	startMutation: (fn: () => void | Promise<void>) => void;
 };
 
@@ -100,91 +165,37 @@ type CartProviderProps = {
 export function CartProvider({ children, initialCart, initialCartId }: CartProviderProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [isMutating, startMutation] = useTransition();
-	const router = useRouter();
+
+	// PLAIN state — no useOptimistic. `dispatch` applies the local mutation for instant
+	// feedback; `syncCart` replaces it with the server's authoritative cart. Because state
+	// never rebases, the local mutation can't be double-applied on top of the synced cart.
+	const [cart, setCart] = useState<Cart | null>(initialCart);
+
+	const dispatch = useCallback((action: CartAction) => setCart((prev) => cartReducer(prev, action)), []);
+	const syncCart = useCallback((next: Cart | null) => {
+		if (next) {
+			setCart(next);
+		}
+	}, []);
+	const reconcile = useCallback(async () => {
+		setCart((await getCart()) as Cart | null);
+	}, []);
 
 	useEffect(() => {
 		// Re-fetch the cart when restored from bfcache — it can change on the hosted
-		// checkout (different origin) and would otherwise show stale items.
+		// checkout (different origin) and would otherwise show stale items. Pull the
+		// authoritative cart directly instead of router.refresh() (which would re-run
+		// the layout's read-replica cartGet and can rebase onto a stale read).
 		const onPageShow = (event: PageTransitionEvent) => {
 			if (event.persisted) {
-				router.refresh();
+				void reconcile();
 			}
 		};
 		window.addEventListener("pageshow", onPageShow);
 		return () => window.removeEventListener("pageshow", onPageShow);
-	}, []);
+	}, [reconcile]);
 
-	const [optimisticCart, dispatchCartAction] = useOptimistic(initialCart, (state, action: CartAction) => {
-		if (!state) {
-			// Handle ADD_ITEM when cart is null
-			if (action.type === "ADD_ITEM") {
-				return {
-					id: "optimistic",
-					lineItems: [action.item],
-				};
-			}
-			return state;
-		}
-
-		switch (action.type) {
-			case "INCREASE":
-				return {
-					...state,
-					lineItems: state.lineItems.map((item) =>
-						item.productVariant.id === action.variantId ? { ...item, quantity: item.quantity + 1 } : item,
-					),
-				};
-
-			case "DECREASE":
-				return {
-					...state,
-					lineItems: state.lineItems
-						.map((item) => {
-							if (item.productVariant.id === action.variantId) {
-								if (item.quantity - 1 <= 0) {
-									return null;
-								}
-								return { ...item, quantity: item.quantity - 1 };
-							}
-							return item;
-						})
-						.filter((item): item is CartLineItem => item !== null),
-				};
-
-			case "REMOVE":
-				return {
-					...state,
-					lineItems: state.lineItems.filter((item) => item.productVariant.id !== action.variantId),
-				};
-
-			case "ADD_ITEM": {
-				const existingItem = state.lineItems.find(
-					(item) => item.productVariant.id === action.item.productVariant.id,
-				);
-
-				if (existingItem) {
-					return {
-						...state,
-						lineItems: state.lineItems.map((item) =>
-							item.productVariant.id === action.item.productVariant.id
-								? { ...item, quantity: item.quantity + action.item.quantity }
-								: item,
-						),
-					};
-				}
-
-				return {
-					...state,
-					lineItems: [...state.lineItems, action.item],
-				};
-			}
-
-			default:
-				return state;
-		}
-	});
-
-	const items = useMemo(() => optimisticCart?.lineItems ?? [], [optimisticCart]);
+	const items = useMemo(() => cart?.lineItems ?? [], [cart]);
 
 	const itemCount = useMemo(() => items.reduce((sum, item) => sum + item.quantity, 0), [items]);
 
@@ -196,13 +207,12 @@ export function CartProvider({ children, initialCart, initialCartId }: CartProvi
 	const openCart = useCallback(() => setIsOpen(true), []);
 	const closeCart = useCallback(() => setIsOpen(false), []);
 
-	// Derive cartId from optimistic cart or initial
-	const currentCartId =
-		optimisticCart?.id && optimisticCart.id !== "optimistic" ? optimisticCart.id : initialCartId;
+	// The sentinel "local" id is only used for a null-base ADD; fall back to the server cart id.
+	const currentCartId = cart?.id && cart.id !== "local" ? cart.id : initialCartId;
 
 	const value = useMemo(
 		() => ({
-			cart: optimisticCart,
+			cart,
 			items,
 			itemCount,
 			subtotal,
@@ -211,11 +221,13 @@ export function CartProvider({ children, initialCart, initialCartId }: CartProvi
 			cartId: currentCartId,
 			openCart,
 			closeCart,
-			dispatch: dispatchCartAction,
+			dispatch,
+			syncCart,
+			reconcile,
 			startMutation,
 		}),
 		[
-			optimisticCart,
+			cart,
 			items,
 			itemCount,
 			subtotal,
@@ -224,7 +236,9 @@ export function CartProvider({ children, initialCart, initialCartId }: CartProvi
 			currentCartId,
 			openCart,
 			closeCart,
-			dispatchCartAction,
+			dispatch,
+			syncCart,
+			reconcile,
 		],
 	);
 

--- a/app/cart/cart-item.tsx
+++ b/app/cart/cart-item.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { Minus, Plus, Trash2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useRef, useTransition } from "react";
 import { setCartQuantity } from "@/app/cart/actions";
-import { type CartLineItem, getLineItemUnitPrice, useCart } from "@/app/cart/cart-context";
+import { type Cart, type CartLineItem, getLineItemUnitPrice, useCart } from "@/app/cart/cart-context";
 import { YnsLink } from "@/components/yns-link";
 import { CURRENCY, LOCALE } from "@/lib/constants";
 import { formatMoney } from "@/lib/money";
@@ -16,8 +15,7 @@ type CartItemProps = {
 };
 
 export function CartItem({ item }: CartItemProps) {
-	const router = useRouter();
-	const { dispatch, closeCart, startMutation } = useCart();
+	const { dispatch, closeCart, startMutation, syncCart, reconcile } = useCart();
 	const [isPending, startTransition] = useTransition();
 
 	const { productVariant, quantity } = item;
@@ -29,6 +27,8 @@ export function CartItem({ item }: CartItemProps) {
 
 	const targetQuantityRef = useRef<number | null>(null);
 	const sendQueueRef = useRef<Promise<void>>(Promise.resolve());
+	const latestCartRef = useRef<Cart | null>(null);
+	const sendFailedRef = useRef(false);
 
 	// Optimistic update + queued sync: rapid clicks collapse into the newest absolute
 	// quantity (safe thanks to mode "set"), one request in flight per line, and each
@@ -51,16 +51,30 @@ export function CartItem({ item }: CartItemProps) {
 						return; // newest value already sent
 					}
 					targetQuantityRef.current = null;
-					await setCartQuantity(productVariant.id, latest);
+					const res = await setCartQuantity(productVariant.id, latest);
+					// Remember the newest server-returned cart so we can sync from it (never
+					// refetch — the layout cartGet hits a read-replica and can rebase stale).
+					if (res.success && res.cart) {
+						latestCartRef.current = res.cart;
+					} else {
+						sendFailedRef.current = true;
+					}
 				});
-				// Drain the queue, then refresh — concurrent transitions land here together,
-				// so their refresh calls batch into one re-render.
+				// Drain the queue, then reconcile once. Concurrent transitions land here
+				// together, so this runs a single sync per batch.
 				let tail: Promise<void>;
 				do {
 					tail = sendQueueRef.current;
 					await tail;
 				} while (tail !== sendQueueRef.current);
-				router.refresh();
+				if (sendFailedRef.current) {
+					sendFailedRef.current = false;
+					latestCartRef.current = null;
+					await reconcile();
+				} else if (latestCartRef.current) {
+					syncCart(latestCartRef.current);
+					latestCartRef.current = null;
+				}
 			} finally {
 				resolveDone();
 			}

--- a/app/product/[slug]/add-to-cart-button.tsx
+++ b/app/product/[slug]/add-to-cart-button.tsx
@@ -62,7 +62,7 @@ export function AddToCartButton({
 }: AddToCartButtonProps) {
 	const searchParams = useSearchParams();
 	const [quantity, setQuantity] = useState(1);
-	const { items, openCart, dispatch, startMutation } = useCart();
+	const { items, openCart, dispatch, syncCart, reconcile, startMutation } = useCart();
 
 	const selectedVariant = useMemo(() => {
 		if (variants.length === 1) {
@@ -166,29 +166,35 @@ export function AddToCartButton({
 		openCart();
 		setQuantity(1);
 
-		startMutation(async () => {
-			dispatch({
-				type: "ADD_ITEM",
-				item: {
-					quantity: addedQuantity,
-					productVariant: {
-						id: variantId,
-						price: selectedVariant.price,
-						images: selectedVariant.images,
-						product,
-					},
+		// Instant local feedback OUTSIDE the transition, then REPLACE with the
+		// server-returned cart (never refetch — the layout cartGet hits a stale
+		// read replica). See patterns/cart-sync.md.
+		dispatch({
+			type: "ADD_ITEM",
+			item: {
+				quantity: addedQuantity,
+				productVariant: {
+					id: variantId,
+					price: selectedVariant.price,
+					images: selectedVariant.images,
+					product,
 				},
-			});
+			},
+		});
 
+		startMutation(async () => {
 			// The server clamps line quantities to available stock and still responds
-			// with the updated cart — compare against what we asked for so the
-			// optimistic item doesn't silently vanish on revert.
+			// with the updated cart — sync from the RETURNED cart; reconcile only on failure.
 			const result = await addToCart(variantId, addedQuantity);
 			const line = result.cart?.lineItems.find((item) => item.productVariant.id === variantId);
-			if (!result.success || !line) {
+			if (result.success && result.cart && line) {
+				syncCart(result.cart);
+				if (line.quantity < previousQuantity + addedQuantity) {
+					toast.warning(`Only ${line.quantity} in stock — quantity adjusted`);
+				}
+			} else {
+				await reconcile();
 				toast.error("This item is out of stock");
-			} else if (line.quantity < previousQuantity + addedQuantity) {
-				toast.warning(`Only ${line.quantity} in stock — quantity adjusted`);
 			}
 		});
 	};

--- a/bun.lock
+++ b/bun.lock
@@ -69,12 +69,13 @@
         "@types/node": "26.1.1",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
+        "@typescript/native-preview": "^7.0.0-dev.20260707.2",
         "babel-plugin-react-compiler": "1.0.0",
         "husky": "9.1.7",
         "lint-staged": "17.2.0",
         "tailwindcss": "4.3.3",
         "tw-animate-css": "1.4.0",
-        "typescript": "^7.0.2",
+        "typescript": "^6",
       },
     },
   },
@@ -461,45 +462,21 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260707.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg=="],
 
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg=="],
 
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw=="],
 
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "arm" }, "sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ=="],
 
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg=="],
 
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "x64" }, "sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA=="],
 
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg=="],
 
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
-
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
-
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
@@ -739,7 +716,7 @@
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/components/quick-add-button.tsx
+++ b/components/quick-add-button.tsx
@@ -2,7 +2,6 @@
 
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { ShoppingBag } from "lucide-react";
-import { startTransition } from "react";
 import { toast } from "sonner";
 import { addToCart } from "@/app/cart/actions";
 import { useCart } from "@/app/cart/cart-context";
@@ -21,7 +20,7 @@ type QuickAddButtonProps = {
 };
 
 export function QuickAddButton({ variantId, variantPrice, variantImages, product }: QuickAddButtonProps) {
-	const { openCart, dispatch } = useCart();
+	const { openCart, dispatch, syncCart, reconcile } = useCart();
 
 	const handleClick = (e: React.MouseEvent) => {
 		e.preventDefault();
@@ -29,28 +28,34 @@ export function QuickAddButton({ variantId, variantPrice, variantImages, product
 
 		openCart();
 
-		startTransition(async () => {
-			dispatch({
-				type: "ADD_ITEM",
-				item: {
-					quantity: 1,
-					productVariant: {
-						id: variantId,
-						price: variantPrice,
-						images: variantImages,
-						product,
-					},
+		// Instant local feedback, then REPLACE with the server-returned cart. No
+		// startTransition (it would defer the instant feedback) and no refetch
+		// (the layout cartGet hits a stale read replica). See patterns/cart-sync.md.
+		dispatch({
+			type: "ADD_ITEM",
+			item: {
+				quantity: 1,
+				productVariant: {
+					id: variantId,
+					price: variantPrice,
+					images: variantImages,
+					product,
 				},
-			});
+			},
+		});
 
+		void (async () => {
 			// The server clamps to available stock and still returns the cart — surface
 			// the failure instead of letting the optimistic item silently vanish.
 			const result = await addToCart(variantId, 1);
 			const line = result.cart?.lineItems.find((item) => item.productVariant.id === variantId);
-			if (!result.success || !line) {
+			if (result.success && result.cart && line) {
+				syncCart(result.cart);
+			} else {
+				await reconcile();
 				toast.error("This item is out of stock");
 			}
-		});
+		})();
 	};
 
 	return (

--- a/components/tiptap-renderer.tsx
+++ b/components/tiptap-renderer.tsx
@@ -30,12 +30,112 @@ const extensions = [
 	Image.configure({ allowBase64: false, inline: true }),
 ];
 
+type Node = TiptapJSONContent;
+
+/** True if a node carries any actual rendered text/media (recursively). */
+function hasMeaningfulContent(node: Node | undefined | null): boolean {
+	if (!node) return false;
+	if (typeof node.text === "string" && node.text.trim().length > 0) return true;
+	// Self-contained media nodes count as meaningful even without text children.
+	if (node.type && ["image", "youtube", "horizontalRule", "hardBreak"].includes(node.type)) {
+		return true;
+	}
+	if (Array.isArray(node.content)) {
+		return node.content.some(hasMeaningfulContent);
+	}
+	return false;
+}
+
+function isListType(node: Node | undefined | null): boolean {
+	return Boolean(node && (node.type === "bulletList" || node.type === "orderedList"));
+}
+
+/**
+ * Prune empty TipTap structures from already-loaded product content:
+ *  (a) listItems whose only content is empty paragraph(s) with no text,
+ *  (b) bulletList/orderedList left with zero items,
+ *  (c) a heading immediately followed by such a now-empty/removed list
+ *      (drops the orphan "Features" heading too).
+ */
+// Node types that may hold INLINE content only. A block nested inside one renders as
+// `<p><p>…</p></p>`, which React rejects at hydration ("<p> cannot be a descendant of <p>").
+const INLINE_ONLY_NODES = new Set(["paragraph", "heading"]);
+const INLINE_NODE_TYPES = new Set(["text", "hardBreak", "image"]);
+
+/**
+ * Lift block nodes out of inline-only parents.
+ *
+ * Source HTML nests blocks inside inline tags (`<b><p>Title</p></b>`), and a store whose catalogue
+ * was imported before the transform-side fix still has that shape stored server-side — 813 of
+ * 4motos.pl's products did. Normalizing here keeps those product pages hydration-clean without
+ * re-importing: inline children stay put and block children are hoisted beside the parent, in
+ * document order.
+ */
+function liftNestedBlocks(nodes: Node[]): Node[] {
+	const out: Node[] = [];
+	for (const node of nodes) {
+		if (!node) continue;
+		const children = node.content ? liftNestedBlocks(node.content) : undefined;
+		if (!children || !node.type || !INLINE_ONLY_NODES.has(node.type)) {
+			out.push(children ? { ...node, content: children } : node);
+			continue;
+		}
+		let run: Node[] = [];
+		const flushRun = () => {
+			if (run.length) out.push({ ...node, content: run });
+			run = [];
+		};
+		for (const child of children) {
+			if (child.type && INLINE_NODE_TYPES.has(child.type)) run.push(child);
+			else {
+				flushRun();
+				out.push(child);
+			}
+		}
+		if (run.length) flushRun();
+	}
+	return out;
+}
+
+function pruneEmptyNodes(nodes: Node[]): Node[] {
+	const cleaned: { node: Node; origNextWasList: boolean }[] = [];
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		if (!node) continue;
+		const child = node.content ? pruneEmptyNodes(node.content) : undefined;
+		const next: Node = child ? { ...node, content: child } : node;
+
+		if (next.type === "listItem" && !hasMeaningfulContent(next)) continue; // (a)
+		if (isListType(next) && (!next.content || next.content.length === 0)) continue; // (b)
+
+		cleaned.push({ node: next, origNextWasList: isListType(nodes[i + 1]) });
+	}
+
+	const result: Node[] = [];
+	for (let i = 0; i < cleaned.length; i++) {
+		const entry = cleaned[i];
+		if (!entry) continue;
+		const { node, origNextWasList } = entry;
+		if (node.type === "heading" && origNextWasList && !isListType(cleaned[i + 1]?.node)) {
+			continue; // orphaned section heading like "Features"
+		}
+		result.push(node);
+	}
+	return result;
+}
+
 export function TiptapRenderer({ content }: { content: JSONContent | null | undefined }) {
 	if (!content) return null;
-	const children = (content as TiptapJSONContent).content;
+	const root = content as TiptapJSONContent;
+	const children = root.content;
 	if (!Array.isArray(children) || children.length === 0) return null;
+
+	const prunedChildren = pruneEmptyNodes(liftNestedBlocks(children));
+	if (prunedChildren.length === 0) return null;
+	const pruned: TiptapJSONContent = { ...root, content: prunedChildren };
+
 	try {
-		return <>{renderToReactElement({ content: content as TiptapJSONContent, extensions })}</>;
+		return <>{renderToReactElement({ content: pruned, extensions })}</>;
 	} catch (error) {
 		console.error("TiptapRenderer failed to render content", error);
 		return null;

--- a/package.json
+++ b/package.json
@@ -76,11 +76,12 @@
 		"@types/node": "26.1.1",
 		"@types/react": "19.2.17",
 		"@types/react-dom": "19.2.3",
+		"@typescript/native-preview": "^7.0.0-dev.20260707.2",
 		"babel-plugin-react-compiler": "1.0.0",
 		"husky": "9.1.7",
 		"lint-staged": "17.2.0",
 		"tailwindcss": "4.3.3",
 		"tw-animate-css": "1.4.0",
-		"typescript": "^7.0.2"
+		"typescript": "^6"
 	}
 }


### PR DESCRIPTION
Three fixes that every generated store currently receives as post-clone patches from the migration tooling — moving them into the template so new stores ship correct from day one.

## 1. `fix(deps)`: TypeScript 6 + tsgo (YNS-1686)

`typescript@^7` is the native Go compiler — it ships `tsc` but **not the JS compiler API Next.js requires**, so every production build fails with `TypeScript 7.0.2 does not provide the compiler API required by Next.js`. It surfaces only on Vercel because `bun dev` uses a different pipeline, and `commerce-kit` peer-depends on `^6.0.3` anyway. `@typescript/native-preview` provides `tsgo` for the lint-staged hook, which previously required a globally installed tsgo (`error: Script not found "tsgo"` otherwise).

## 2. `fix(cart)`: replace the `useOptimistic` cart with server-reconciled state

The most re-reported bug across generated stores: `useOptimistic` re-applies the pending action on top of the synced base mid-transition — add doubles-then-reverts, quantities change on *other* lines, items "add then disappear" after `revalidatePath` refetches a stale replica. The cart now holds plain state replaced by the server action's returned cart; a stale `yns_cart` cookie is caught and retried with a fresh cart. This is the `cart-sync` pattern already applied to every migrated store; the 5-step race smoke (double-add / second product / ± a line / reload) passes.

## 3. `fix(product)`: TipTap renderer hardening

Imported catalogues carry TipTap docs converted from arbitrary source HTML. Block nodes nested in paragraphs (`<b><p>…</p></b>`) render `<p><p>` and **throw at hydration** (813 of one store's 6,028 products); empty list structures render blank "Features" sections. The renderer now lifts nested blocks (document order preserved, no content loss), prunes empty nodes, and returns null instead of crashing when the static renderer throws.

## Verification

- `bun run build` passes on the committed state (full route table; previously fails under typescript@^7)
- `bun tsgo --noEmit` clean (runs in the pre-commit hook on every commit here)
- The dep pair + both fixes are live on a deployed store (4motos.yns.store) — build, hydration-clean product pages, and the cart smoke verified in production
- Once merged, the migration tooling's codemods detect the fixes via their anchors and no-op automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
