### PR TITLE
docs: restore the star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ git for-each-ref --sort=refname --format='%(refname:short)  %(subject)' 'refs/re
 
 ## Star History
 
-<a href="https://star-history.com/#yournextstore/yournextstore&Date">
+<a href="https://star-history.dera.page/#yournextstore/yournextstore&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=yournextstore/yournextstore&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=yournextstore/yournextstore&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=yournextstore/yournextstore&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=yournextstore/yournextstore&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=yournextstore/yournextstore&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=yournextstore/yournextstore&type=Date" width="600" />
   </picture>
 </a>


### PR DESCRIPTION
The star history chart on the README is currently broken: the images no longer load, so the section renders as empty boxes on both light and dark themes. This is caused by GitHub stargazer API restrictions that the old chart relied on.

This change points the chart at a working instance that pulls from a different data source, so the chart renders again for every visitor. The wrapping link is also updated to match the new URL format.

The chart itself is small and cosmetic, but it is the first thing contributors see, so restoring it keeps the README looking polished.